### PR TITLE
✨ add Flag Timeout

### DIFF
--- a/src/struct/commands/CommandHandler.ts
+++ b/src/struct/commands/CommandHandler.ts
@@ -1022,8 +1022,7 @@ export class CommandHandler extends AkairoHandler {
 			if (Flag.is(args, FlagType.Cancel)) {
 				this.emit(CommandHandlerEvents.COMMAND_CANCELLED, message, command);
 				return true;
-			}
-			if (Flag.is(args, FlagType.Timeout)) {
+			} else if (Flag.is(args, FlagType.Timeout)) {
 				this.emit(CommandHandlerEvents.COMMAND_TIMEOUT, message, command, args.time);
 				return true;
 			} else if (Flag.is(args, FlagType.Retry)) {

--- a/src/struct/commands/CommandHandler.ts
+++ b/src/struct/commands/CommandHandler.ts
@@ -1022,7 +1022,8 @@ export class CommandHandler extends AkairoHandler {
 			if (Flag.is(args, FlagType.Cancel)) {
 				this.emit(CommandHandlerEvents.COMMAND_CANCELLED, message, command);
 				return true;
-			} if (Flag.is(args, FlagType.Timeout)) {
+			}
+			if (Flag.is(args, FlagType.Timeout)) {
 				this.emit(CommandHandlerEvents.COMMAND_TIMEOUT, message, command, args.time);
 				return true;
 			} else if (Flag.is(args, FlagType.Retry)) {

--- a/src/struct/commands/CommandHandler.ts
+++ b/src/struct/commands/CommandHandler.ts
@@ -1022,6 +1022,9 @@ export class CommandHandler extends AkairoHandler {
 			if (Flag.is(args, FlagType.Cancel)) {
 				this.emit(CommandHandlerEvents.COMMAND_CANCELLED, message, command);
 				return true;
+			} if (Flag.is(args, FlagType.Timeout)) {
+				this.emit(CommandHandlerEvents.COMMAND_TIMEOUT, message, command, args.time);
+				return true;
 			} else if (Flag.is(args, FlagType.Retry)) {
 				this.emit(CommandHandlerEvents.COMMAND_BREAKOUT, message, command, args.message);
 				return this.handle(args.message);

--- a/src/struct/commands/Flag.ts
+++ b/src/struct/commands/Flag.ts
@@ -10,6 +10,13 @@ export class Flag<T extends FlagType = FlagType> {
 	public declare type: T;
 
 	/**
+	 * Order waiting time .
+	 *
+	 * Only exists if {@link type} is {@link FlagType.Timeout}.
+	 */
+	public declare time: T extends FlagType.Timeout ? number : never;
+
+	/**
 	 * Message to handle.
 	 *
 	 * Only exists if {@link type} is {@link FlagType.Retry}.
@@ -43,16 +50,18 @@ export class Flag<T extends FlagType = FlagType> {
 	 * Only exists if {@link type} is {@link FlagType.Continue}.
 	 */
 	public declare rest: T extends FlagType.Continue ? string | null : never;
+	
 
 	/**
 	 * @param type - Type of flag.
 	 * @param data - Extra data.
 	 */
 	private constructor(type: T & FlagType.Cancel);
+	private constructor(type: T & FlagType.Timeout, data?: FlagTimeoutData);
 	private constructor(type: T & FlagType.Retry, data?: FlagRetryData);
 	private constructor(type: T & FlagType.Fail, data?: FlagFailData);
 	private constructor(type: T & FlagType.Continue, data?: FlagContinueData);
-	private constructor(type: T, data: Record<string, never> | FlagRetryData | FlagFailData | FlagContinueData = {}) {
+	private constructor(type: T, data: Record<string, never> | FlagTimeoutData | FlagRetryData | FlagFailData | FlagContinueData = {}) {
 		this.type = type;
 		Object.assign(this, data);
 	}
@@ -63,6 +72,13 @@ export class Flag<T extends FlagType = FlagType> {
 	public static cancel(): Flag<FlagType.Cancel> {
 		return new Flag(FlagType.Cancel);
 	}
+
+		/**
+	 * Create a flag that cancels the command because of the timeout
+	 */
+		 public static timeout(time: number): Flag<FlagType.Timeout> {
+			return new Flag(FlagType.Timeout, {time});
+		}
 
 	/**
 	 * Creates a flag that retries with another input.
@@ -96,6 +112,7 @@ export class Flag<T extends FlagType = FlagType> {
 	 * @param type - Type of flag.
 	 */
 	public static is(value: unknown, type: FlagType.Cancel): value is Flag<FlagType.Cancel>;
+	public static is(value: unknown, type: FlagType.Timeout): value is Flag<FlagType.Timeout>;
 	public static is(value: unknown, type: FlagType.Continue): value is Flag<FlagType.Continue>;
 	public static is(value: unknown, type: FlagType.Fail): value is Flag<FlagType.Fail>;
 	public static is(value: unknown, type: FlagType.Retry): value is Flag<FlagType.Retry>;
@@ -106,9 +123,14 @@ export class Flag<T extends FlagType = FlagType> {
 
 export enum FlagType {
 	Cancel = "cancel",
+	Timeout = "timeout",
 	Retry = "retry",
 	Fail = "fail",
 	Continue = "continue"
+}
+
+interface FlagTimeoutData {
+	time: number;
 }
 
 interface FlagRetryData {

--- a/src/struct/commands/Flag.ts
+++ b/src/struct/commands/Flag.ts
@@ -50,7 +50,6 @@ export class Flag<T extends FlagType = FlagType> {
 	 * Only exists if {@link type} is {@link FlagType.Continue}.
 	 */
 	public declare rest: T extends FlagType.Continue ? string | null : never;
-	
 
 	/**
 	 * @param type - Type of flag.
@@ -61,7 +60,10 @@ export class Flag<T extends FlagType = FlagType> {
 	private constructor(type: T & FlagType.Retry, data?: FlagRetryData);
 	private constructor(type: T & FlagType.Fail, data?: FlagFailData);
 	private constructor(type: T & FlagType.Continue, data?: FlagContinueData);
-	private constructor(type: T, data: Record<string, never> | FlagTimeoutData | FlagRetryData | FlagFailData | FlagContinueData = {}) {
+	private constructor(
+		type: T,
+		data: Record<string, never> | FlagTimeoutData | FlagRetryData | FlagFailData | FlagContinueData = {}
+	) {
 		this.type = type;
 		Object.assign(this, data);
 	}
@@ -73,12 +75,12 @@ export class Flag<T extends FlagType = FlagType> {
 		return new Flag(FlagType.Cancel);
 	}
 
-		/**
+	/**
 	 * Create a flag that cancels the command because of the timeout
 	 */
-		 public static timeout(time: number): Flag<FlagType.Timeout> {
-			return new Flag(FlagType.Timeout, {time});
-		}
+	public static timeout(time: number): Flag<FlagType.Timeout> {
+		return new Flag(FlagType.Timeout, { time });
+	}
 
 	/**
 	 * Creates a flag that retries with another input.

--- a/src/struct/commands/arguments/Argument.ts
+++ b/src/struct/commands/arguments/Argument.ts
@@ -314,7 +314,6 @@ export class Argument {
 				const time = promptOptions?.time ? this.command.argumentDefaults.prompt?.time : 30000;
 				if (!time) return Flag.cancel();
 				return Flag.timeout(time);
-				
 			}
 
 			if (promptOptions.breakout) {

--- a/src/struct/commands/arguments/Argument.ts
+++ b/src/struct/commands/arguments/Argument.ts
@@ -311,9 +311,8 @@ export class Argument {
 					const sentTimeout = await message.channel.send(timeoutText);
 					if (message.util) message.util.addMessage(sentTimeout);
 				}
-				const time = promptOptions?.time ? this.command.argumentDefaults.prompt?.time : 30000;
-				if (!time) return Flag.cancel();
-				return Flag.timeout(time);
+				if (!promptOptions.time) return Flag.cancel();
+				return Flag.timeout(promptOptions.time);
 			}
 
 			if (promptOptions.breakout) {

--- a/src/struct/commands/arguments/Argument.ts
+++ b/src/struct/commands/arguments/Argument.ts
@@ -311,8 +311,10 @@ export class Argument {
 					const sentTimeout = await message.channel.send(timeoutText);
 					if (message.util) message.util.addMessage(sentTimeout);
 				}
-
-				return Flag.cancel();
+				const time = promptOptions?.time ? this.command.argumentDefaults.prompt?.time : 30000;
+				if (!time) return Flag.cancel();
+				return Flag.timeout(time);
+				
 			}
 
 			if (promptOptions.breakout) {

--- a/src/typings/events.ts
+++ b/src/typings/events.ts
@@ -49,6 +49,14 @@ export interface CommandHandlerEvents extends AkairoHandlerEvents {
 	commandCancelled: [message: Message, command: Command, retryMessage?: Message];
 
 	/**
+	 * Emitted when a command is cancelled becouse of a timeout.
+	 * @param message - Message sent.
+	 * @param command - Command executed.
+	 * @param time - Timeout in milliseconds.
+	 */
+	 commandTimeout: [message: Message, command: Command, time: number];
+
+	/**
 	 * Emitted when a command finishes execution.
 	 * @param message - Message sent.
 	 * @param command - Command executed.

--- a/src/typings/events.ts
+++ b/src/typings/events.ts
@@ -54,7 +54,7 @@ export interface CommandHandlerEvents extends AkairoHandlerEvents {
 	 * @param command - Command executed.
 	 * @param time - Timeout in milliseconds.
 	 */
-	 commandTimeout: [message: Message, command: Command, time: number];
+	commandTimeout: [message: Message, command: Command, time: number];
 
 	/**
 	 * Emitted when a command finishes execution.

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -72,7 +72,6 @@ export enum AkairoHandlerEvents {
 	REMOVE = "remove"
 }
 
-
 export enum CommandHandlerEvents {
 	COMMAND_BLOCKED = "commandBlocked",
 	COMMAND_BREAKOUT = "commandBreakout",
@@ -94,7 +93,7 @@ export enum CommandHandlerEvents {
 	SLASH_MISSING_PERMISSIONS = "slashMissingPermissions",
 	SLASH_NOT_FOUND = "slashNotFound",
 	SLASH_STARTED = "slashStarted",
-	SLASH_ONLY = "slashOnly",
+	SLASH_ONLY = "slashOnly"
 }
 
 export enum ContextCommandHandlerEvents {

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -72,10 +72,12 @@ export enum AkairoHandlerEvents {
 	REMOVE = "remove"
 }
 
+
 export enum CommandHandlerEvents {
 	COMMAND_BLOCKED = "commandBlocked",
 	COMMAND_BREAKOUT = "commandBreakout",
 	COMMAND_CANCELLED = "commandCancelled",
+	COMMAND_TIMEOUT = "commandTimeout",
 	COMMAND_FINISHED = "commandFinished",
 	COMMAND_INVALID = "commandInvalid",
 	COMMAND_LOCKED = "commandLocked",
@@ -92,7 +94,7 @@ export enum CommandHandlerEvents {
 	SLASH_MISSING_PERMISSIONS = "slashMissingPermissions",
 	SLASH_NOT_FOUND = "slashNotFound",
 	SLASH_STARTED = "slashStarted",
-	SLASH_ONLY = "slashOnly"
+	SLASH_ONLY = "slashOnly",
 }
 
 export enum ContextCommandHandlerEvents {


### PR DESCRIPTION
Add a timeout flag to not have a cancel flag when the event is of type timeout.

This would add a new "commandTimeout" event which would take the same parameters as the "commandCancel" event but would add "time" of type number.

Example for the event

```js
const { Listener } = require("discord-akairo");

class CommandTimeout extends Listener {
	constructor() {
		super("commandTimeout", {
			emitter: "commandHandler",
			event: "commandTimeout",
			category: "command",
		});
	}

    /**
   * @param time {number}
   */
	times(time) {
		const date = new Date(time);
		const minutes = date.getMinutes();
		const seconds = date.getSeconds();
		if (minutes > 1) {
			return `**${minutes}** minutes`;
		}
		return `**${seconds}** seconds`;
	}

	/**
     * @param message {import("discord.js").Message}
     * @param command {import("discord-akairo").Command}
     * @param time {number}
     */
	async exec(message, command, time) {

		message.channel.send({ embeds: [
			{
				color: "YELLOW",
				description: `💡 The ${this.times(time)} are up!`,
			},
		] });
	}
}

module.exports = CommandTimeout;
```


Can be very handy to do a default integration like below
![image](https://user-images.githubusercontent.com/52933626/173761698-eb6b8c06-3a09-4939-a269-4790b6c41039.png)
